### PR TITLE
docs: add run command to clone installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ cd loom-downloader
 
 # Install dependencies
 npm install
+
+# Run the tool
+node loom-dl.js --url https://www.loom.com/share/[VideoId]
 ```
 
 ### 🔧 Dependencies


### PR DESCRIPTION
## Summary

- Adds `node loom-dl.js --url ...` run command to the "Clone Repository" installation option, so users know how to actually run the tool after cloning.

Closes #12 (related context in [comment](https://github.com/EcomGraduates/loom-downloader/issues/12#issuecomment-3850152959))