### PR TITLE
feat: add --use-title flag to name downloads by video title

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ This adds a **5-second delay** between each download. Adjust the timeout value a
 | `--image` | | Also download the video thumbnail (JPG) | `--image` |
 | `--gif` | | Also download the video thumbnail as GIF | `--gif` |
 | `--seek-preview` | | Also download seek preview sprite + VTT (scrubber thumbnails) | `--seek-preview` |
+| `--use-title` | | Use video title as filename instead of video ID | `--use-title` |
 | `--mcp` | | Start as MCP server (for AI assistants) | `--mcp` |
 
 ### Use as MCP server (AI assistants)
@@ -189,6 +190,12 @@ loom-dl --list videos.txt --prefix "course" --out ./downloads
 
 # Batch download with rate limiting
 loom-dl --list videos.txt --timeout 3000 --prefix "meeting"
+
+# Download with original video title as filename
+loom-dl --url https://www.loom.com/share/abc123def456 --use-title
+
+# Batch download using video titles as filenames
+loom-dl --list videos.txt --out ./downloads --use-title
 ```
 
 ## ⚙️ Configuration Management

--- a/loom-dl.js
+++ b/loom-dl.js
@@ -128,6 +128,10 @@ const argv = yargs(hideBin(process.argv))
     type: 'boolean',
     description: 'Also download the seek preview sprite image and VTT (for scrubber thumbnails)'
   })
+  .option('use-title', {
+    type: 'boolean',
+    description: 'Use the video title as the filename instead of the video ID'
+  })
   .option('save-config', {
     type: 'boolean',
     description: 'Save current options as defaults'
@@ -569,6 +573,9 @@ const extractId = (url) => {
 
 const delay = (ms) => new Promise(r => setTimeout(r, ms));
 
+const sanitizeFilename = (name) =>
+  name.replace(/[\\/:*?"<>|]/g, '-').replace(/\s+/g, ' ').trim().slice(0, 200);
+
 const appendToLogFile = async (id) => {
   await fsPromises.appendFile(path.join(__dirname, 'downloaded.log'), `${id}\n`);
 };
@@ -616,7 +623,8 @@ const downloadSingleFile = async () => {
   if (argv.out && path.extname(argv.out) !== '') {
     videoPath = path.resolve(argv.out);
   } else {
-    videoPath = getOutputPath(id, outputDir, 'mp4');
+    const basename = argv['use-title'] && info.title ? sanitizeFilename(info.title) : id;
+    videoPath = getOutputPath(basename, outputDir, 'mp4');
   }
   
   const transcriptPath = videoPath.replace(/\.mp4$/, '.transcript.json');
@@ -694,7 +702,8 @@ const downloadFromList = async () => {
     const id = extractId(url);
     try {
       const info = await fetchLoomVideoInfo(id);
-      const filename = argv.prefix ? `${argv.prefix}-${urls.indexOf(url) + 1}-${id}` : id;
+      const titleBase = argv['use-title'] && info.title ? sanitizeFilename(info.title) : id;
+      const filename = argv.prefix ? `${argv.prefix}-${urls.indexOf(url) + 1}-${titleBase}` : titleBase;
       const videoPath = path.join(outputDirectory, `${filename}.mp4`);
       const transcriptPath = path.join(outputDirectory, `${filename}.transcript.json`);
       


### PR DESCRIPTION
Summary
Adds --use-title CLI flag that names downloaded files using the Loom video's actual title instead of the video ID
Adds sanitizeFilename() helper to strip filesystem-unsafe characters (\ / : * ? " < > |) and truncate at 200 chars
Works in both single --url and batch --list modes; falls back to video ID if title unavailable
Usage

# Before: 316bf463411446c2939dabd7ed610bce.mp4
# After:  How to Create a Job.mp4

loom-dl --list urls.txt --out ./downloads --use-title
loom-dl --url https://www.loom.com/share/abc123 --use-title